### PR TITLE
Fix to make the code compile with latest gcc.

### DIFF
--- a/src/proposed-method/src/03-AdjacentBoneSeparation.hpp
+++ b/src/proposed-method/src/03-AdjacentBoneSeparation.hpp
@@ -302,7 +302,7 @@ vector<pair<Label, Label> > getSubIslandsPairsForSeparation(
         ) {
 
             Label subIsland = subIslandsSortedBySize[mainIdx];
-            log("Computing distace from sub-island %d") % subIsland;
+            logger("Computing distace from sub-island %d") % subIsland;
 
             FloatImagePtr distance =
                 FilterUtils<UIntImage,FloatImage>::distanceMapByFastMarcher(
@@ -450,11 +450,11 @@ UCharImagePtr compute(UCharImagePtr inputBinary) {
     unsigned EROSION_RADIUS = 3;
     unsigned MAX_DISTANCE_FOR_ADJACENT_BONES = 15;
 
-    log("Computing Connected Components");
+    logger("Computing Connected Components");
     UIntImagePtr mainIslands =
         FilterUtils<UCharImage,UIntImage>::connectedComponents(inputBinary);
 
-    log("Erosion + Connected Components, ball radius=%d") % EROSION_RADIUS;
+    logger("Erosion + Connected Components, ball radius=%d") % EROSION_RADIUS;
     UIntImagePtr subIslands =
         FilterUtils<UCharImage,UIntImage>::connectedComponents(
             FilterUtils<UCharImage>::erosion(inputBinary, EROSION_RADIUS)
@@ -468,7 +468,7 @@ UCharImagePtr compute(UCharImagePtr inputBinary) {
     and between 13 and 12 -> three bottlenecks altogether. Clearly,
     the subislands 5 and 2 must lie within the same main island.
     */
-    log("Discovering main islands containg bottlenecks");
+    logger("Discovering main islands containg bottlenecks");
     IslandStats stats = countSizeOfIslands(mainIslands, subIslands);
     markIslandsToProcess(stats);
     vector<pair<unsigned, unsigned> > subIslandsPairs =
@@ -479,7 +479,7 @@ UCharImagePtr compute(UCharImagePtr inputBinary) {
     UIntImagePtr result = ImageUtils<UIntImage>::duplicate(mainIslands);
 
 
-    log("Number of bottlenecks to be found: %d") % subIslandsPairs.size();
+    logger("Number of bottlenecks to be found: %d") % subIslandsPairs.size();
 
     /*
     Let's find the bottlenecks using simplified graph-cut
@@ -492,7 +492,7 @@ UCharImagePtr compute(UCharImagePtr inputBinary) {
         Label mainLabel = findLabelOfMainIsland(mainIslands, subIslands, i1);
         assert(mainLabel == findLabelOfMainIsland(mainIslands, subIslands, i2));
 
-        log("Identifying bottleneck between sub-islands %d and %d within main island %d")
+        logger("Identifying bottleneck between sub-islands %d and %d within main island %d")
             % i1 % i2 % mainLabel;
 
         // for the graph-cut we need to supply roi and the cost function

--- a/src/proposed-method/src/Globals.hpp
+++ b/src/proposed-method/src/Globals.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#define AVAILABLE_MEMORY_IN_MB  2000
+#define AVAILABLE_MEMORY_IN_MB  200
 
 
 #include "itkImage.h"
@@ -46,11 +46,7 @@ typedef UCharImage::SizeType ImageSize;
 typedef UCharImage::IndexType ImageIndex;
 typedef UCharImage::RegionType ImageRegion;
 
-
-
-
-
-#define log mylog << boost::format
+#define logger mylog << boost::format
 #define logSetStage(stage) mylog.setStage(stage)
 
 class MyLog {
@@ -79,4 +75,3 @@ public:
 
 };
 MyLog mylog;
-

--- a/src/proposed-method/src/Globals.hpp
+++ b/src/proposed-method/src/Globals.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#define AVAILABLE_MEMORY_IN_MB  200
+#define AVAILABLE_MEMORY_IN_MB  2000
 
 
 #include "itkImage.h"

--- a/src/proposed-method/src/ImageSplitter.hpp
+++ b/src/proposed-method/src/ImageSplitter.hpp
@@ -158,7 +158,7 @@ private:
         unsigned memoryNeededKb;
         vector<SliceSet> sliceSets;
 
-        log("Maximum available memory is %d MB") % AVAILABLE_MEMORY_IN_MB;
+        logger("Maximum available memory is %d MB") % AVAILABLE_MEMORY_IN_MB;
 
 
         while (!enoughRAMforEachBlock && blocks < MAX_BLOCKS) {
@@ -183,7 +183,7 @@ private:
 
             enoughRAMforEachBlock = (memoryNeededKb < availableMemoryKb);
 
-            log("Probing %1% block(s): %2%, graph-cut expected memory consumption %3% Mb")
+            logger("Probing %1% block(s): %2%, graph-cut expected memory consumption %3% Mb")
                 % blocks
                 % (enoughRAMforEachBlock ? "OK" : "Not enough")
                 % (memoryNeededKb / 1024);

--- a/src/proposed-method/src/Main.cxx
+++ b/src/proposed-method/src/Main.cxx
@@ -106,7 +106,7 @@ int main(int argc, char * argv [])
 
     {
         logSetStage("Init");
-        log("Loading image %s") % filenames.input();
+        logger("Loading image %s") % filenames.input();
         ShortImagePtr inputCT = ImageUtils<ShortImage>::readImage(filenames.input());
 
         logSetStage("Preprocessing");
@@ -166,14 +166,14 @@ int main(int argc, char * argv [])
             inputCT, roi, sheetness, softTissueEst);
 
         // save the result
-        log("Saving temporal result to %s") % filenames.segmOutputPart(i);
+        logger("Saving temporal result to %s") % filenames.segmOutputPart(i);
         ImageUtils<UCharImage>::writeImage(filenames.segmOutputPart(i), gcResult);
 
     }
 
 
     logSetStage("Assembly");
-    log("Assembling temporal results");
+    logger("Assembling temporal results");
 
     UCharImagePtr assembledResult = FilterUtils<UCharImage>::createEmptyFrom(
         ImageUtils<UCharImage>::readImage(filenames.roi()));
@@ -203,7 +203,7 @@ int main(int argc, char * argv [])
 	//-----------------------------------
 
     logSetStage("Saving");
-    log("Writing the result to %s") % filenames.output();
+    logger("Writing the result to %s") % filenames.output();
 
     ImageUtils<UCharImage>::writeImage(filenames.output(), finalResult);
 

--- a/src/proposed-method/src/filters/ChamferDistanceTransform.hpp
+++ b/src/proposed-method/src/filters/ChamferDistanceTransform.hpp
@@ -244,7 +244,7 @@ private:
 public:
 
     // constructor
-    ChamferDistanceTransform() : _propagationImage(NULL)
+    ChamferDistanceTransform() : _propagationImage(nullptr)
     {}
 
     void setPropagationImage(PropagationImagePointer p) {
@@ -296,10 +296,10 @@ public:
         // compute the template for the given distance transfortm type
         ChamferTemplate chamferTemplate = getForwardTemplate(type);
 
-        log("Chamfer Distance Forward sweep");
+        logger("Chamfer Distance Forward sweep");
         forwardSweep(distanceMap, chamferTemplate);
 
-        log("Chamfer Distance Backward sweep");
+        logger("Chamfer Distance Backward sweep");
         backwardSweep(distanceMap, chamferTemplate);
 
         // done :)

--- a/src/proposed-method/src/filters/GraphCut.hpp
+++ b/src/proposed-method/src/filters/GraphCut.hpp
@@ -255,7 +255,7 @@ private:
     ) {
         assignIdsToPixels(labelImage);
 
-        log("Building graph, %d nodes") % _totalPixelsInROI;
+        logger("Building graph, %d nodes") % _totalPixelsInROI;
 
         _gc = new GraphType(_totalPixelsInROI, 3 * _totalPixelsInROI);
         _gc->add_node(_totalPixelsInROI);
@@ -263,7 +263,7 @@ private:
         initializeDataCosts(dataCostFunction);
 
         initializeNeighbours(smoothnessCostFunction);
-        log("%d t-links added") % _totalNeighbors;
+        logger("%d t-links added") % _totalNeighbors;
 
 //#if LOG_GRAPH_CUT_DETAILS == 1
 //        logger.log("Segm - Graph nodes", _totalPixelsInROI);
@@ -284,9 +284,9 @@ private:
 
         assert(_gc != NULL);
 
-        log("Graph built. Computing the max flow");
+        logger("Graph built. Computing the max flow");
         _gc->maxflow();
-        log("Max flow computed");
+        logger("Max flow computed");
         updateLabelImageAccordingToGraph();
 
         // Ende :)

--- a/src/proposed-method/src/filters/SheetnessMeasure.hpp
+++ b/src/proposed-method/src/filters/SheetnessMeasure.hpp
@@ -270,7 +270,7 @@ void MemoryEfficientObjectnessFilter::GenerateObjectnessImage()
 	}
 	mean_norm /= (float)pixelsInRoi;
 
-    log("Mean norm = %1%") % mean_norm;
+    logger("Mean norm = %1%") % mean_norm;
 
 	for (int k=0 ; k<d ; k++)
 	{


### PR DESCRIPTION
- Replaced variable name `log` by `logger`, as the name conflicts with `std::log()`. 
- fixed `nullptr` use in the case of a smart pointer.
- fixed the signature for `multiscaleSheetness()` to avoid ambiguous conversion error